### PR TITLE
Hotfix 1.3.5 alpha

### DIFF
--- a/simulation/models/achilles/model.sdf
+++ b/simulation/models/achilles/model.sdf
@@ -24,6 +24,24 @@
 					</box>
 				</geometry>
 			</collision>
+
+            <collision name ='base_link_left_tire_block_blocker'>
+				<pose>0.16 0.13 -0.05 0 0.0 0.0</pose>
+				<geometry>
+					<box>
+					  <size>0.005 0.08 0.06</size>
+					</box>
+				</geometry>
+            </collision>
+            <collision name ='base_link_right_tire_block_blocker'>
+				<pose>0.16 -0.13 -0.05 0 0.0 0.0</pose>
+				<geometry>
+					<box>
+					  <size>0.005 0.08 0.06</size>
+					</box>
+				</geometry>
+            </collision>
+
 			<visual name='base_link_visual'>
 				<pose>0 0 -0.06 0 0 0</pose>
 				<geometry>

--- a/simulation/models/aeneas/model.sdf
+++ b/simulation/models/aeneas/model.sdf
@@ -24,6 +24,24 @@
 					</box>
 				</geometry>
 			</collision>
+
+            <collision name ='base_link_left_tire_block_blocker'>
+				<pose>0.16 0.13 -0.05 0 0.0 0.0</pose>
+				<geometry>
+					<box>
+					  <size>0.005 0.08 0.06</size>
+					</box>
+				</geometry>
+            </collision>
+            <collision name ='base_link_right_tire_block_blocker'>
+				<pose>0.16 -0.13 -0.05 0 0.0 0.0</pose>
+				<geometry>
+					<box>
+					  <size>0.005 0.08 0.06</size>
+					</box>
+				</geometry>
+            </collision>
+
 			<visual name='base_link_visual'>
 				<pose>0 0 -0.06 0 0 0</pose>
 				<geometry>

--- a/simulation/models/ajax/model.sdf
+++ b/simulation/models/ajax/model.sdf
@@ -24,6 +24,24 @@
 					</box>
 				</geometry>
 			</collision>
+
+            <collision name ='base_link_left_tire_block_blocker'>
+				<pose>0.16 0.13 -0.05 0 0.0 0.0</pose>
+				<geometry>
+					<box>
+					  <size>0.005 0.08 0.06</size>
+					</box>
+				</geometry>
+            </collision>
+            <collision name ='base_link_right_tire_block_blocker'>
+				<pose>0.16 -0.13 -0.05 0 0.0 0.0</pose>
+				<geometry>
+					<box>
+					  <size>0.005 0.08 0.06</size>
+					</box>
+				</geometry>
+            </collision>
+
 			<visual name='base_link_visual'>
 				<pose>0 0 -0.06 0 0 0</pose>
 				<geometry>

--- a/simulation/models/diomedes/model.sdf
+++ b/simulation/models/diomedes/model.sdf
@@ -24,6 +24,24 @@
 					</box>
 				</geometry>
 			</collision>
+
+            <collision name ='base_link_left_tire_block_blocker'>
+				<pose>0.16 0.13 -0.05 0 0.0 0.0</pose>
+				<geometry>
+					<box>
+					  <size>0.005 0.08 0.06</size>
+					</box>
+				</geometry>
+            </collision>
+            <collision name ='base_link_right_tire_block_blocker'>
+				<pose>0.16 -0.13 -0.05 0 0.0 0.0</pose>
+				<geometry>
+					<box>
+					  <size>0.005 0.08 0.06</size>
+					</box>
+				</geometry>
+            </collision>
+
 			<visual name='base_link_visual'>
 				<pose>0 0 -0.06 0 0 0</pose>
 				<geometry>

--- a/simulation/models/hector/model.sdf
+++ b/simulation/models/hector/model.sdf
@@ -24,6 +24,24 @@
 					</box>
 				</geometry>
 			</collision>
+
+            <collision name ='base_link_left_tire_block_blocker'>
+				<pose>0.16 0.13 -0.05 0 0.0 0.0</pose>
+				<geometry>
+					<box>
+					  <size>0.005 0.08 0.06</size>
+					</box>
+				</geometry>
+            </collision>
+            <collision name ='base_link_right_tire_block_blocker'>
+				<pose>0.16 -0.13 -0.05 0 0.0 0.0</pose>
+				<geometry>
+					<box>
+					  <size>0.005 0.08 0.06</size>
+					</box>
+				</geometry>
+            </collision>
+
 			<visual name='base_link_visual'>
 				<pose>0 0 -0.06 0 0 0</pose>
 				<geometry>

--- a/simulation/models/paris/model.sdf
+++ b/simulation/models/paris/model.sdf
@@ -24,6 +24,24 @@
 					</box>
 				</geometry>
 			</collision>
+
+            <collision name ='base_link_left_tire_block_blocker'>
+				<pose>0.16 0.13 -0.05 0 0.0 0.0</pose>
+				<geometry>
+					<box>
+					  <size>0.005 0.08 0.06</size>
+					</box>
+				</geometry>
+            </collision>
+            <collision name ='base_link_right_tire_block_blocker'>
+				<pose>0.16 -0.13 -0.05 0 0.0 0.0</pose>
+				<geometry>
+					<box>
+					  <size>0.005 0.08 0.06</size>
+					</box>
+				</geometry>
+            </collision>
+
 			<visual name='base_link_visual'>
 				<pose>0 0 -0.06 0 0 0</pose>
 				<geometry>

--- a/simulation/models/thor/model.sdf
+++ b/simulation/models/thor/model.sdf
@@ -6,6 +6,7 @@
 
 		<link name='base_link'>
 			<inertial>
+<<<<<<< HEAD
 				<mass>3</mass>
 				<inertia>
 					<ixx>0.006</ixx>
@@ -14,6 +15,16 @@
 					<iyy>0.006</iyy>
 					<iyz>0.0</iyz>
 					<izz>0.006</izz>
+=======
+				<mass>3.0</mass>
+				<inertia>
+					<ixx>0.06</ixx>
+					<ixy>0.0</ixy>
+					<ixz>0.0</ixz>
+					<iyy>0.06</iyy>
+					<iyz>0.0</iyz>
+					<izz>0.06</izz>
+>>>>>>> SwarmBaseCode-ROS/hotfix-1.3.5-alpha
 				</inertia>
 			</inertial>
 			<collision name='base_link_collision'>
@@ -24,6 +35,27 @@
 					</box>
 				</geometry>
 			</collision>
+<<<<<<< HEAD
+=======
+
+            <collision name ='base_link_left_tire_block_blocker'>
+				<pose>0.16 0.13 -0.05 0 0.0 0.0</pose>
+				<geometry>
+					<box>
+					  <size>0.005 0.08 0.06</size>
+					</box>
+				</geometry>
+            </collision>
+            <collision name ='base_link_right_tire_block_blocker'>
+				<pose>0.16 -0.13 -0.05 0 0.0 0.0</pose>
+				<geometry>
+					<box>
+					  <size>0.005 0.08 0.06</size>
+					</box>
+				</geometry>
+            </collision>
+
+>>>>>>> SwarmBaseCode-ROS/hotfix-1.3.5-alpha
 			<visual name='base_link_visual'>
 				<pose>0 0 -0.06 0 0 0</pose>
 				<geometry>
@@ -93,7 +125,11 @@
 				<visualize>false</visualize>
 				<update_rate>5</update_rate>
 				<ray>
+<<<<<<< HEAD
 					<scan>3.0
+=======
+					<scan>
+>>>>>>> SwarmBaseCode-ROS/hotfix-1.3.5-alpha
 						<horizontal>
 							<samples>3</samples>
 							<resolution>1.0</resolution>
@@ -202,13 +238,21 @@
 				</geometry>
 				<material>
 					<script>
+<<<<<<< HEAD
 						<name>Gazebo/FlatBlack</name>
+=======
+						<name>Gazebo/Turquoise</name>
+>>>>>>> SwarmBaseCode-ROS/hotfix-1.3.5-alpha
 					</script>
 				</material>
 			</visual>
 
 			<collision name='cow_catcher_back_lower_collision'>
+<<<<<<< HEAD
 				<pose>-0.1305 0.0 -0.0665 1.57079 1.05 0.0</pose>
+=======
+				<pose>-0.1375 0.0 -0.0725 1.57079 1.05 0.0</pose>
+>>>>>>> SwarmBaseCode-ROS/hotfix-1.3.5-alpha
 				<geometry>
 					<box>
 					  <size>0.01 0.03 0.18</size>
@@ -225,7 +269,11 @@
 				</geometry>
 				<material>
 					<script>
+<<<<<<< HEAD
 						<name>Gazebo/FlatBlack</name>
+=======
+						<name>Gazebo/Turquoise</name>
+>>>>>>> SwarmBaseCode-ROS/hotfix-1.3.5-alpha
 					</script>
 				</material>
 			</visual>
@@ -237,12 +285,21 @@
 			<inertial>
 				<mass>0.03</mass>
 				<inertia> 
+<<<<<<< HEAD
 					<ixx>0.00245</ixx> <!--> 1/12*(mass)(h^2 + d^2) where h,d,w are in meters and mass is in kilograms <-->
 					<ixy>0.0</ixy>
 					<ixz>0.0</ixz>
 					<iyy>0.00185</iyy> <!--> 1/12*(mass)(w^2 + d^2) <-->
 					<iyz>0.0</iyz>
 					<izz>0.00185</izz> <!--> 1/12*(mass)(w^2 + h^2) <-->
+=======
+					<ixx>0.245</ixx> <!--> 1/12*(mass)(h^2 + d^2) where h,d,w are in meters and mass is in kilograms <-->
+					<ixy>0.0</ixy>
+					<ixz>0.0</ixz>
+					<iyy>0.185</iyy> <!--> 1/12*(mass)(w^2 + d^2) <-->
+					<iyz>0.0</iyz>
+					<izz>0.185</izz> <!--> 1/12*(mass)(w^2 + h^2) <-->
+>>>>>>> SwarmBaseCode-ROS/hotfix-1.3.5-alpha
 				</inertia>
 			</inertial>
 
@@ -288,7 +345,11 @@
 		<link name="gripper_left_finger">
 			<pose>0.214 0.016 0.0095 0 0 0</pose>
 			<inertial>
+<<<<<<< HEAD
 				<mass>0.005</mass>
+=======
+				<mass>0.001</mass>
+>>>>>>> SwarmBaseCode-ROS/hotfix-1.3.5-alpha
 				<inertia>
 					<ixx>0.0000833</ixx>
 					<ixy>0.0</ixy>
@@ -369,7 +430,11 @@
 		<link name="gripper_right_finger">
 			<pose>0.214 -0.016 0.0095 0 0 0</pose>
 			<inertial>
+<<<<<<< HEAD
  				<mass>0.005</mass>
+=======
+ 				<mass>0.001</mass>
+>>>>>>> SwarmBaseCode-ROS/hotfix-1.3.5-alpha
 				<inertia>
 					<ixx>0.0000833</ixx>
 					<ixy>0.0</ixy>
@@ -411,7 +476,11 @@
 					</friction>
 				</surface>
 			</collision>
+<<<<<<< HEAD
 			<visual name="visual">3.0
+=======
+			<visual name="visual">
+>>>>>>> SwarmBaseCode-ROS/hotfix-1.3.5-alpha
 				<pose>0 0 0 0 0 0</pose>
 				<geometry>
 					<mesh>
@@ -452,12 +521,21 @@
 			<inertial>
 				<mass>0.05</mass>
 				<inertia>
+<<<<<<< HEAD
 					<ixx>0.000776</ixx>
 					<ixy>0.0</ixy>
 					<ixz>0.0</ixz>
 					<iyy>0.0012</iyy>
 					<iyz>0.0</iyz>
 					<izz>0.000776</izz>
+=======
+					<ixx>0.000082</ixx>
+					<ixy>0.0</ixy>
+					<ixz>0.0</ixz>
+					<iyy>0.000063</iyy>
+					<iyz>0.0</iyz>
+					<izz>0.000082</izz>
+>>>>>>> SwarmBaseCode-ROS/hotfix-1.3.5-alpha
 				</inertia>
 			</inertial>
 			<collision name="collision">
@@ -504,12 +582,21 @@
 			<inertial>
 				<mass>0.05</mass>
 				<inertia>
+<<<<<<< HEAD
          <ixx>0.000776</ixx>
          <ixy>0.0</ixy>
          <ixz>0.0</ixz>
          <iyy>0.0012</iyy>
          <iyz>0.0</iyz>
          <izz>0.000776</izz>
+=======
+					<ixx>0.000082</ixx>
+					<ixy>0.0</ixy>
+					<ixz>0.0</ixz>
+					<iyy>0.000063</iyy>
+					<iyz>0.0</iyz>
+					<izz>0.000082</izz>
+>>>>>>> SwarmBaseCode-ROS/hotfix-1.3.5-alpha
 				</inertia>
 			</inertial>
 			<collision name="collision">
@@ -556,12 +643,21 @@
 			<inertial>
 				<mass>0.05</mass>
 				<inertia>
+<<<<<<< HEAD
          <ixx>0.000776</ixx>
          <ixy>0.0</ixy>
          <ixz>0.0</ixz>
          <iyy>0.0012</iyy>
          <iyz>0.0</iyz>
          <izz>0.000776</izz>
+=======
+					<ixx>0.000082</ixx>
+					<ixy>0.0</ixy>
+					<ixz>0.0</ixz>
+					<iyy>0.000082</iyy>
+					<iyz>0.0</iyz>
+					<izz>0.000063</izz>
+>>>>>>> SwarmBaseCode-ROS/hotfix-1.3.5-alpha
 				</inertia>
 			</inertial>
 			<collision name="collision">
@@ -608,12 +704,21 @@
 			<inertial>
 				<mass>0.05</mass>
 				<inertia>
+<<<<<<< HEAD
          <ixx>0.000776</ixx>
          <ixy>0.0</ixy>
          <ixz>0.0</ixz>
          <iyy>0.0012</iyy>
          <iyz>0.0</iyz>
          <izz>0.000776</izz>
+=======
+					<ixx>0.000082</ixx>
+					<ixy>0.0</ixy>
+					<ixz>0.0</ixz>
+					<iyy>0.000063</iyy>
+					<iyz>0.0</iyz>
+					<izz>0.000082</izz>
+>>>>>>> SwarmBaseCode-ROS/hotfix-1.3.5-alpha
 				</inertia>
 			</inertial>
 			<collision name="collision">

--- a/simulation/models/zeus/model.sdf
+++ b/simulation/models/zeus/model.sdf
@@ -6,6 +6,7 @@
 
 		<link name='base_link'>
 			<inertial>
+<<<<<<< HEAD
 				<mass>3</mass>
 				<inertia>
 					<ixx>0.006</ixx>
@@ -14,6 +15,16 @@
 					<iyy>0.006</iyy>
 					<iyz>0.0</iyz>
 					<izz>0.006</izz>
+=======
+				<mass>3.0</mass>
+				<inertia>
+					<ixx>0.06</ixx>
+					<ixy>0.0</ixy>
+					<ixz>0.0</ixz>
+					<iyy>0.06</iyy>
+					<iyz>0.0</iyz>
+					<izz>0.06</izz>
+>>>>>>> SwarmBaseCode-ROS/hotfix-1.3.5-alpha
 				</inertia>
 			</inertial>
 			<collision name='base_link_collision'>
@@ -24,6 +35,27 @@
 					</box>
 				</geometry>
 			</collision>
+<<<<<<< HEAD
+=======
+
+            <collision name ='base_link_left_tire_block_blocker'>
+				<pose>0.16 0.13 -0.05 0 0.0 0.0</pose>
+				<geometry>
+					<box>
+					  <size>0.005 0.08 0.06</size>
+					</box>
+				</geometry>
+            </collision>
+            <collision name ='base_link_right_tire_block_blocker'>
+				<pose>0.16 -0.13 -0.05 0 0.0 0.0</pose>
+				<geometry>
+					<box>
+					  <size>0.005 0.08 0.06</size>
+					</box>
+				</geometry>
+            </collision>
+
+>>>>>>> SwarmBaseCode-ROS/hotfix-1.3.5-alpha
 			<visual name='base_link_visual'>
 				<pose>0 0 -0.06 0 0 0</pose>
 				<geometry>
@@ -93,7 +125,11 @@
 				<visualize>false</visualize>
 				<update_rate>5</update_rate>
 				<ray>
+<<<<<<< HEAD
 					<scan>3.0
+=======
+					<scan>
+>>>>>>> SwarmBaseCode-ROS/hotfix-1.3.5-alpha
 						<horizontal>
 							<samples>3</samples>
 							<resolution>1.0</resolution>
@@ -202,13 +238,21 @@
 				</geometry>
 				<material>
 					<script>
+<<<<<<< HEAD
 						<name>Gazebo/FlatBlack</name>
+=======
+						<name>Gazebo/Indigo</name>
+>>>>>>> SwarmBaseCode-ROS/hotfix-1.3.5-alpha
 					</script>
 				</material>
 			</visual>
 
 			<collision name='cow_catcher_back_lower_collision'>
+<<<<<<< HEAD
 				<pose>-0.1305 0.0 -0.0665 1.57079 1.05 0.0</pose>
+=======
+				<pose>-0.1375 0.0 -0.0725 1.57079 1.05 0.0</pose>
+>>>>>>> SwarmBaseCode-ROS/hotfix-1.3.5-alpha
 				<geometry>
 					<box>
 					  <size>0.01 0.03 0.18</size>
@@ -225,7 +269,11 @@
 				</geometry>
 				<material>
 					<script>
+<<<<<<< HEAD
 						<name>Gazebo/FlatBlack</name>
+=======
+						<name>Gazebo/Indigo</name>
+>>>>>>> SwarmBaseCode-ROS/hotfix-1.3.5-alpha
 					</script>
 				</material>
 			</visual>
@@ -237,12 +285,21 @@
 			<inertial>
 				<mass>0.03</mass>
 				<inertia> 
+<<<<<<< HEAD
 					<ixx>0.00245</ixx> <!--> 1/12*(mass)(h^2 + d^2) where h,d,w are in meters and mass is in kilograms <-->
 					<ixy>0.0</ixy>
 					<ixz>0.0</ixz>
 					<iyy>0.00185</iyy> <!--> 1/12*(mass)(w^2 + d^2) <-->
 					<iyz>0.0</iyz>
 					<izz>0.00185</izz> <!--> 1/12*(mass)(w^2 + h^2) <-->
+=======
+					<ixx>0.245</ixx> <!--> 1/12*(mass)(h^2 + d^2) where h,d,w are in meters and mass is in kilograms <-->
+					<ixy>0.0</ixy>
+					<ixz>0.0</ixz>
+					<iyy>0.185</iyy> <!--> 1/12*(mass)(w^2 + d^2) <-->
+					<iyz>0.0</iyz>
+					<izz>0.185</izz> <!--> 1/12*(mass)(w^2 + h^2) <-->
+>>>>>>> SwarmBaseCode-ROS/hotfix-1.3.5-alpha
 				</inertia>
 			</inertial>
 
@@ -288,7 +345,11 @@
 		<link name="gripper_left_finger">
 			<pose>0.214 0.016 0.0095 0 0 0</pose>
 			<inertial>
+<<<<<<< HEAD
 				<mass>0.005</mass>
+=======
+				<mass>0.001</mass>
+>>>>>>> SwarmBaseCode-ROS/hotfix-1.3.5-alpha
 				<inertia>
 					<ixx>0.0000833</ixx>
 					<ixy>0.0</ixy>
@@ -369,7 +430,11 @@
 		<link name="gripper_right_finger">
 			<pose>0.214 -0.016 0.0095 0 0 0</pose>
 			<inertial>
+<<<<<<< HEAD
  				<mass>0.005</mass>
+=======
+ 				<mass>0.001</mass>
+>>>>>>> SwarmBaseCode-ROS/hotfix-1.3.5-alpha
 				<inertia>
 					<ixx>0.0000833</ixx>
 					<ixy>0.0</ixy>
@@ -411,7 +476,11 @@
 					</friction>
 				</surface>
 			</collision>
+<<<<<<< HEAD
 			<visual name="visual">3.0
+=======
+			<visual name="visual">
+>>>>>>> SwarmBaseCode-ROS/hotfix-1.3.5-alpha
 				<pose>0 0 0 0 0 0</pose>
 				<geometry>
 					<mesh>
@@ -452,12 +521,21 @@
 			<inertial>
 				<mass>0.05</mass>
 				<inertia>
+<<<<<<< HEAD
 					<ixx>0.000776</ixx>
 					<ixy>0.0</ixy>
 					<ixz>0.0</ixz>
 					<iyy>0.0012</iyy>
 					<iyz>0.0</iyz>
 					<izz>0.000776</izz>
+=======
+					<ixx>0.000082</ixx>
+					<ixy>0.0</ixy>
+					<ixz>0.0</ixz>
+					<iyy>0.000063</iyy>
+					<iyz>0.0</iyz>
+					<izz>0.000082</izz>
+>>>>>>> SwarmBaseCode-ROS/hotfix-1.3.5-alpha
 				</inertia>
 			</inertial>
 			<collision name="collision">
@@ -504,12 +582,21 @@
 			<inertial>
 				<mass>0.05</mass>
 				<inertia>
+<<<<<<< HEAD
          <ixx>0.000776</ixx>
          <ixy>0.0</ixy>
          <ixz>0.0</ixz>
          <iyy>0.0012</iyy>
          <iyz>0.0</iyz>
          <izz>0.000776</izz>
+=======
+					<ixx>0.000082</ixx>
+					<ixy>0.0</ixy>
+					<ixz>0.0</ixz>
+					<iyy>0.000063</iyy>
+					<iyz>0.0</iyz>
+					<izz>0.000082</izz>
+>>>>>>> SwarmBaseCode-ROS/hotfix-1.3.5-alpha
 				</inertia>
 			</inertial>
 			<collision name="collision">
@@ -556,12 +643,21 @@
 			<inertial>
 				<mass>0.05</mass>
 				<inertia>
+<<<<<<< HEAD
          <ixx>0.000776</ixx>
          <ixy>0.0</ixy>
          <ixz>0.0</ixz>
          <iyy>0.0012</iyy>
          <iyz>0.0</iyz>
          <izz>0.000776</izz>
+=======
+					<ixx>0.000082</ixx>
+					<ixy>0.0</ixy>
+					<ixz>0.0</ixz>
+					<iyy>0.000082</iyy>
+					<iyz>0.0</iyz>
+					<izz>0.000063</izz>
+>>>>>>> SwarmBaseCode-ROS/hotfix-1.3.5-alpha
 				</inertia>
 			</inertial>
 			<collision name="collision">
@@ -608,12 +704,21 @@
 			<inertial>
 				<mass>0.05</mass>
 				<inertia>
+<<<<<<< HEAD
          <ixx>0.000776</ixx>
          <ixy>0.0</ixy>
          <ixz>0.0</ixz>
          <iyy>0.0012</iyy>
          <iyz>0.0</iyz>
          <izz>0.000776</izz>
+=======
+					<ixx>0.000082</ixx>
+					<ixy>0.0</ixy>
+					<ixz>0.0</ixz>
+					<iyy>0.000063</iyy>
+					<iyz>0.0</iyz>
+					<izz>0.000082</izz>
+>>>>>>> SwarmBaseCode-ROS/hotfix-1.3.5-alpha
 				</inertia>
 			</inertial>
 			<collision name="collision">


### PR DESCRIPTION
 updated rover model files with bumper collision boxes

The problem:
    The rovers keep driving up on top of cubes, which deviates from
    the normal behaviour found in physical rovers.

The solution:
    Bumper collision boxes have been added in front of the wheels to
    prevent them from riding on top of cubes and getting stuck.