### PR TITLE
Implement physical rover global frame

### DIFF
--- a/src/behaviours/src/ROSAdapter.cpp
+++ b/src/behaviours/src/ROSAdapter.cpp
@@ -330,11 +330,11 @@ void behaviourStateMachine(const ros::TimerEvent&)
 	      logicController.SetCenterLocationOdom(centerOdom);
 
         // Set the global offset for physical rovers; we assume that a robot
-        // is placed a specified distance from the center as defined with the
-        // centerOdom variable..
+        // is placed a specified distance from the center... This position
+        // will be the negative of centerOdom.
         std_msgs::Float32MultiArray centerOdomOffsetMessage;
-        centerOdomOffsetMessage.data.push_back(centerOdom.x);
-        centerOdomOffsetMessage.data.push_back(centerOdom.y);
+        centerOdomOffsetMessage.data.push_back(-centerOdom.x);
+        centerOdomOffsetMessage.data.push_back(-centerOdom.y);
         centerOdomOffsetMessage.data.push_back(centerOdom.theta);
         centerLocationOffsetPublisher.publish(centerOdomOffsetMessage);
 

--- a/src/behaviours/src/ROSAdapter.cpp
+++ b/src/behaviours/src/ROSAdapter.cpp
@@ -50,13 +50,13 @@ public:
   ROSAdapterRangeShapeInvalidTypeException(std::string msg) {
     this->msg = msg;
   }
-  
+
   virtual const char* what() const throw()
   {
     std::string message = "Invalid RangeShape type provided: " + msg;
     return message.c_str();
   }
-  
+
 private:
   std::string msg;
 };
@@ -124,7 +124,7 @@ float arena_dim =0.0; //qilu 01/2018
 
 vector<Point> roverPositions;
 vector<string> roverNames;
-	
+
 geometry_msgs::Twist velocity;
 char host[128];
 string publishedName;
@@ -147,13 +147,14 @@ ros::Publisher heartbeatPublisher;
 ros::Publisher waypointFeedbackPublisher;
 ros::Publisher namePublish;
 ros::Publisher obstaclePubisher;
+ros::Publisher centerLocationOffsetPublisher;
 
 // Publishes swarmie_msgs::Waypoint messages on "/<robot>/waypooints"
 // to indicate when waypoints have been reached.
 
 // Subscribers
 ros::Subscriber joySubscriber;
-ros::Subscriber modeSubscriber; 
+ros::Subscriber modeSubscriber;
 ros::Subscriber targetSubscriber;
 ros::Subscriber odometrySubscriber;
 ros::Subscriber mapSubscriber;
@@ -174,7 +175,7 @@ ros::Timer publish_heartbeat_timer;
 // records time for delays in sequanced actions, 1 second resolution.
 time_t timerStartTime;
 
-// An initial delay to allow the rover to gather enough position data to 
+// An initial delay to allow the rover to gather enough position data to
 // average its location.
 unsigned int startDelayInSeconds = 30;
 unsigned int timerTimeElapsed = 0;
@@ -205,47 +206,47 @@ void sonarHandler(const sensor_msgs::Range::ConstPtr& sonarLeft, const sensor_ms
 long int getROSTimeInMilliSecs();
 
 
-      
+
 int main(int argc, char **argv) {
-  
+
   gethostname(host, sizeof (host));
   string hostname(host);
-  
-  if (argc >= 2) 
+
+  if (argc >= 2)
   {
     publishedName = argv[1];
     cout << "Welcome to the world of tomorrow " << publishedName
          << "!  Behaviour turnDirectionule started." << endl;
-  } 
-  else 
+  }
+  else
   {
     publishedName = hostname;
     cout << "No Name Selected. Default is: " << publishedName << endl;
   }
-  
+
   // NoSignalHandler so we can catch SIGINT ourselves and shutdown the node
   ros::init(argc, argv, (publishedName + "_BEHAVIOUR"), ros::init_options::NoSigintHandler);
   ros::NodeHandle mNH;
-  
+
   // Register the SIGINT event handler so the node can shutdown properly
   signal(SIGINT, sigintEventHandler);
-  
+
   joySubscriber = mNH.subscribe((publishedName + "/joystick"), 10, joyCmdHandler);
   modeSubscriber = mNH.subscribe((publishedName + "/mode"), 1, modeHandler);
   targetSubscriber = mNH.subscribe((publishedName + "/targets"), 10, targetHandler);
   odometrySubscriber = mNH.subscribe((publishedName + "/odom/filtered"), 10, odometryHandler);
   mapSubscriber = mNH.subscribe((publishedName + "/odom/ekf"), 10, mapHandler);
-  
+
   roverSubscriber = mNH.subscribe("/rovers", 10, roverHandler);
   nameSubscriber = mNH.subscribe("/names", 36, nameHandler);
   virtualFenceSubscriber = mNH.subscribe(("/virtualFence"), 10, virtualFenceHandler);
   arenaDimSubscriber = mNH.subscribe("/arena_dim", 10, arenaDimHandler); //qilu 08/2017
-  
+
   manualWaypointSubscriber = mNH.subscribe((publishedName + "/waypoints/cmd"), 10, manualWaypointHandler);
   message_filters::Subscriber<sensor_msgs::Range> sonarLeftSubscriber(mNH, (publishedName + "/sonarLeft"), 10);
   message_filters::Subscriber<sensor_msgs::Range> sonarCenterSubscriber(mNH, (publishedName + "/sonarCenter"), 10);
   message_filters::Subscriber<sensor_msgs::Range> sonarRightSubscriber(mNH, (publishedName + "/sonarRight"), 10);
-  
+
   obstaclePubisher = mNH.advertise<std_msgs::UInt8>((publishedName + "/obstacle"), 10, true);
   status_publisher = mNH.advertise<std_msgs::String>((publishedName + "/status"), 1, true);
   stateMachinePublisher = mNH.advertise<std_msgs::String>((publishedName + "/state_machine"), 1, true);
@@ -256,13 +257,14 @@ int main(int argc, char **argv) {
   heartbeatPublisher = mNH.advertise<std_msgs::String>((publishedName + "/behaviour/heartbeat"), 1, true);
   waypointFeedbackPublisher = mNH.advertise<swarmie_msgs::Waypoint>((publishedName + "/waypoints"), 1, true);
   namePublish = mNH.advertise<std_msgs::String>("/names", 6, true);
+  centerLocationOffsetPublisher = mNH.advertise<std_msgs::Float32MultiArray>((publishedName + "/centerLocationOffset"), 10, true);
   publish_status_timer = mNH.createTimer(ros::Duration(status_publish_interval), publishStatusTimerEventHandler);
   stateMachineTimer = mNH.createTimer(ros::Duration(behaviourLoopTimeStep), behaviourStateMachine);
-  
+
   publish_heartbeat_timer = mNH.createTimer(ros::Duration(heartbeat_publish_interval), publishHeartBeatTimerEventHandler);
-  
+
   typedef message_filters::sync_policies::ApproximateTime<sensor_msgs::Range, sensor_msgs::Range, sensor_msgs::Range> sonarSyncPolicy;
-  
+
   message_filters::Synchronizer<sonarSyncPolicy> sonarSync(sonarSyncPolicy(10), sonarLeftSubscriber, sonarCenterSubscriber, sonarRightSubscriber);
   sonarSync.registerCallback(boost::bind(&sonarHandler, _1, _2, _3));
   tfListener = new tf::TransformListener();
@@ -283,7 +285,7 @@ int main(int argc, char **argv) {
 
   timerStartTime = time(0);
   ros::spin();
-  
+
   return EXIT_SUCCESS;
 }
 
@@ -296,16 +298,16 @@ void behaviourStateMachine(const ros::TimerEvent&)
 {
   int roverIdx=0;
   std_msgs::String stateMachineMsg;
-  
+
   // time since timerStartTime was set to current time
   timerTimeElapsed = time(0) - timerStartTime;
-  
+
       std_msgs::String name_msg;
       name_msg.data = publishedName;
       namePublish.publish(name_msg);
 
   // Robot is in automode
-  if (currentMode == 2 || currentMode == 3) 
+  if (currentMode == 2 || currentMode == 3)
   {
 	    // init code goes here. (code that runs only once at start of
   // auto mode but wont work in main goes here)
@@ -313,31 +315,43 @@ void behaviourStateMachine(const ros::TimerEvent&)
       {
 		if (timerTimeElapsed > startDelayInSeconds)
 	    {
-	
 	      // initialization has run
 	      //cout<<"initialization has run..."<<endl;
 	      initilized = true;
-	      //TODO: this just sets center to 0 over and over and needs to change
+
+        // This sets the center odom position based on its starting position
+        // and the assumption that the robots will be placed a given number
+        // of meters from the center of the collection zone (in this case it
+        // is 1.308 meters).
 	      Point centerOdom;
 	      centerOdom.x = 1.308 * cos(currentLocation.theta);
 	      centerOdom.y = 1.308 * sin(currentLocation.theta);
 	      centerOdom.theta = centerLocation.theta;
 	      logicController.SetCenterLocationOdom(centerOdom);
-	      
+
+        // Set the global offset for physical rovers; we assume that a robot
+        // is placed a specified distance from the center as defined with the
+        // centerOdom variable..
+        std_msgs::Float32MultiArray centerOdomOffsetMessage;
+        centerOdomOffsetMessage.data.push_back(centerOdom.x);
+        centerOdomOffsetMessage.data.push_back(centerOdom.y);
+        centerOdomOffsetMessage.data.push_back(centerOdom.theta);
+        centerLocationOffsetPublisher.publish(centerOdomOffsetMessage);
+
 	      Point centerMap;
 	      centerMap.x = currentLocationMap.x + (1.308 * cos(currentLocationMap.theta));
 	      centerMap.y = currentLocationMap.y + (1.308 * sin(currentLocationMap.theta));
 	      centerMap.theta = centerLocationMap.theta;
 	      logicController.SetCenterLocationMap(centerMap);
-	      
+
 	      centerLocationMap.x = centerMap.x;
 	      centerLocationMap.y = centerMap.y;
-	      
+
 	      centerLocationOdom.x = centerOdom.x;
 	      centerLocationOdom.y = centerOdom.y;
-	      
+
 	      startTime = getROSTimeInMilliSecs();
-	      
+
 		  logicController.SetArenaSize(arena_dim);
 	    }
 	    else
@@ -359,21 +373,21 @@ void behaviourStateMachine(const ros::TimerEvent&)
     }
 
     humanTime();
-    
+
     //update the time used by all the controllers
     logicController.SetCurrentTimeInMilliSecs( getROSTimeInMilliSecs() );
-    
+
     //update center location
     if(logicController.CreatedFirstWayPoint())
     {
     logicController.SetCenterLocationOdom( updateCenterLocation() );
 		}
-    
+
     //ask logic controller for the next set of actuator commands
     result = logicController.DoWork();
-    
+
     bool wait = false;
-    
+
     //if a wait behaviour is thrown sit and do nothing untill logicController is ready
     if (result.type == behavior)
     {
@@ -382,25 +396,25 @@ void behaviourStateMachine(const ros::TimerEvent&)
         wait = true;
       }
     }
-    
+
     //do this when wait behaviour happens
     if (wait)
     {
       sendDriveCommand(0.0,0.0);
       std_msgs::Float32 angle;
-      
+
       angle.data = prevFinger;
       fingerAnglePublisher.publish(angle);
       angle.data = prevWrist;
       wristAnglePublisher.publish(angle);
     }
-    
+
     //normally interpret logic controllers actuator commands and deceminate them over the appropriate ROS topics
     else
     {
-      
+
       sendDriveCommand(result.pd.left,result.pd.right);
-      
+
 
       //Alter finger and wrist angle is told to reset with last stored value if currently has -1 value
       std_msgs::Float32 angle;
@@ -418,16 +432,16 @@ void behaviourStateMachine(const ros::TimerEvent&)
         prevWrist = result.wristAngle;
       }
     }
-    
+
     collision_msg.data = logicController.getCollisionCalls();
     obstaclePubisher.publish(collision_msg);
-   
+
     //publishHandeling here
     //logicController.getPublishData(); suggested
     //adds a blank space between sets of debugging data to easily tell one tick from the next
     //cout << endl;
   }
-  
+
   // mode is NOT auto
   else
   {
@@ -484,10 +498,10 @@ void sendDriveCommand(double left, double right)
 void targetHandler(const apriltags_ros::AprilTagDetectionArray::ConstPtr& message) {
 
   // Don't pass April tag data to the logic controller if the robot is not in autonomous mode.
-  // This is to make sure autonomous behaviours are not triggered while the rover is in manual mode. 
-  if(currentMode == 0 || currentMode == 1) 
-  { 
-    return; 
+  // This is to make sure autonomous behaviours are not triggered while the rover is in manual mode.
+  if(currentMode == 0 || currentMode == 1)
+  {
+    return;
   }
 
   bool ignored_tag = false;
@@ -497,14 +511,14 @@ void targetHandler(const apriltags_ros::AprilTagDetectionArray::ConstPtr& messag
   if (message->detections.size() > 0) {
     vector<Tag> tags;
 
-    for (int i = 0; i < message->detections.size(); i++) 
+    for (int i = 0; i < message->detections.size(); i++)
     {
 
       // Package up the ROS AprilTag data into our own type that does not rely on ROS.
       Tag loc;
       loc.setID( message->detections[i].id );
 
-      if (loc.getID() == 0) 
+      if (loc.getID() == 0)
       {
         num_cube_tags++;
       }
@@ -512,7 +526,7 @@ void targetHandler(const apriltags_ros::AprilTagDetectionArray::ConstPtr& messag
       {
 	    num_center_tags++;
 	  }
-	  
+
       // Pass the position of the AprilTag
       geometry_msgs::PoseStamped tagPose = message->detections[i].pose;
       loc.setPosition( make_tuple( tagPose.pose.position.x,
@@ -532,16 +546,16 @@ void targetHandler(const apriltags_ros::AprilTagDetectionArray::ConstPtr& messag
 		centerLocationMap.x = currentLocationMap.x + 1.0*cos(currentLocationMap.theta);
         centerLocationMap.y = currentLocationMap.y + 1.0*sin(currentLocationMap.theta);
         centerLocationOdom.x = currentLocation.x + 1.0*cos(currentLocation.theta);
-        centerLocationOdom.y = currentLocation.y + + 1.0*sin(currentLocation.theta);  
+        centerLocationOdom.y = currentLocation.y + + 1.0*sin(currentLocation.theta);
         //cout<<"TestStatusA: centerLocationMap=["<<centerLocationMap.x<<", "<<centerLocationMap.y<<"]"<<endl;
         //cout<<"TestStatusA: centerLocationOdom=["<<centerLocationOdom.x<<", "<<centerLocationOdom.y<<"]"<<endl;
 	}
-    
-        
-    
+
+
+
     logicController.SetAprilTags(tags);
   }
-  
+
 }
 
 void modeHandler(const std_msgs::UInt8::ConstPtr& message) {
@@ -555,8 +569,8 @@ void modeHandler(const std_msgs::UInt8::ConstPtr& message) {
   sendDriveCommand(0.0, 0.0);
 }
 
-void sonarHandler(const sensor_msgs::Range::ConstPtr& sonarLeft, const sensor_msgs::Range::ConstPtr& sonarCenter, const sensor_msgs::Range::ConstPtr& sonarRight) 
-{ 
+void sonarHandler(const sensor_msgs::Range::ConstPtr& sonarLeft, const sensor_msgs::Range::ConstPtr& sonarCenter, const sensor_msgs::Range::ConstPtr& sonarRight)
+{
   logicController.SetSonarData(sonarLeft->range, sonarCenter->range, sonarRight->range);
 }
 
@@ -569,35 +583,35 @@ void arenaDimHandler(const std_msgs::Float32::ConstPtr& message)
 void roverHandler(const swarmie_msgs::RoverInfo& message)
 {
 	swarmie_msgs::RoverInfo rover_info = message;
-	
+
 	for(int i=0; i < rover_info.names.size(); i++)
 	{
 		//cout<<"TestStatus: rover["<<i<<"]="<<rover_info.names[i]<<endl;
 		roverNames.push_back(rover_info.names[i]);
-		
+
 		//cout<<"TestStatus: rover["<<i<<"] pos=["<<rover_info.positions[i].x<<", "<<rover_info.positions[i].y<<"]"<<endl;
-		
+
 		Point pos(rover_info.positions[i].x, rover_info.positions[i].y, rover_info.positions[i].theta);
-		roverPositions.push_back(pos);		 
-	} 
+		roverPositions.push_back(pos);
+	}
 }
-	
+
 void odometryHandler(const nav_msgs::Odometry::ConstPtr& message) {
   //Get (x,y) location directly from pose
   currentLocation.x = message->pose.pose.position.x;
   currentLocation.y = message->pose.pose.position.y;
-  
+
   //Get theta rotation by converting quaternion orientation to pitch/roll/yaw
   tf::Quaternion q(message->pose.pose.orientation.x, message->pose.pose.orientation.y, message->pose.pose.orientation.z, message->pose.pose.orientation.w);
   tf::Matrix3x3 m(q);
   double roll, pitch, yaw;
   m.getRPY(roll, pitch, yaw);
   currentLocation.theta = yaw;
-  
+
   linearVelocity = message->twist.twist.linear.x;
   angularVelocity = message->twist.twist.angular.z;
-  
-  
+
+
   Point currentLoc;
   currentLoc.x = currentLocation.x;
   currentLoc.y = currentLocation.y;
@@ -607,7 +621,7 @@ void odometryHandler(const nav_msgs::Odometry::ConstPtr& message) {
 }
 
 // Allows a virtual fence to be defined and enabled or disabled through ROS
-void virtualFenceHandler(const std_msgs::Float32MultiArray& message) 
+void virtualFenceHandler(const std_msgs::Float32MultiArray& message)
 {
   // Read data from the message array
   // The first element is an integer indicating the shape type
@@ -615,7 +629,7 @@ void virtualFenceHandler(const std_msgs::Float32MultiArray& message)
   // 1 = circle
   // 2 = rectangle
   int shape_type = static_cast<int>(message.data[0]); // Shape type
-  
+
   if (shape_type == 0)
   {
     logicController.setVirtualFenceOff();
@@ -626,22 +640,22 @@ void virtualFenceHandler(const std_msgs::Float32MultiArray& message)
     Point center;
     center.x = message.data[1]; // Range center x
     center.y = message.data[2]; // Range center y
-    
+
     // If the shape type is "circle" then element 4 is the radius, if rectangle then width
     switch ( shape_type )
     {
     case 1: // Circle
     {
       if ( message.data.size() != 4 ) throw ROSAdapterRangeShapeInvalidTypeException("Wrong number of parameters for circle shape type in ROSAdapter.cpp:virtualFenceHandler()");
-      float radius = message.data[3]; 
+      float radius = message.data[3];
       logicController.setVirtualFenceOn( new RangeCircle(center, radius) );
       break;
     }
-    case 2: // Rectangle 
+    case 2: // Rectangle
     {
       if ( message.data.size() != 5 ) throw ROSAdapterRangeShapeInvalidTypeException("Wrong number of parameters for rectangle shape type in ROSAdapter.cpp:virtualFenceHandler()");
-      float width = message.data[3]; 
-      float height = message.data[4]; 
+      float width = message.data[3];
+      float height = message.data[4];
       logicController.setVirtualFenceOn( new RangeRectangle(center, width, height) );
       break;
     }
@@ -657,17 +671,17 @@ void mapHandler(const nav_msgs::Odometry::ConstPtr& message) {
   //Get (x,y) location directly from pose
   currentLocationMap.x = message->pose.pose.position.x;
   currentLocationMap.y = message->pose.pose.position.y;
-  
+
   //Get theta rotation by converting quaternion orientation to pitch/roll/yaw
   tf::Quaternion q(message->pose.pose.orientation.x, message->pose.pose.orientation.y, message->pose.pose.orientation.z, message->pose.pose.orientation.w);
   tf::Matrix3x3 m(q);
   double roll, pitch, yaw;
   m.getRPY(roll, pitch, yaw);
   currentLocationMap.theta = yaw;
-  
+
   linearVelocity = message->twist.twist.linear.x;
   angularVelocity = message->twist.twist.angular.z;
-  
+
   Point curr_loc;
   curr_loc.x = currentLocationMap.x;
   curr_loc.y = currentLocationMap.y;
@@ -785,43 +799,43 @@ long int getROSTimeInMilliSecs()
   ros::Time t = ros::Time::now();
   // Convert from seconds and nanoseconds to milliseconds.
   return t.sec*1e3 + t.nsec/1e6;
-  
+
 }
 
 
 Point updateCenterLocation()
 {
   transformMapCentertoOdom();
-  
+
   Point tmp;
   tmp.x = centerLocationOdom.x;
   tmp.y = centerLocationOdom.y;
-  
+
   return tmp;
 }
 
 void transformMapCentertoOdom()
 {
-  
+
   // map frame
   geometry_msgs::PoseStamped mapPose;
-  
+
   // setup msg to represent the center location in map frame
   mapPose.header.stamp = ros::Time::now();
-  
+
   mapPose.header.frame_id = publishedName + "/map";
   mapPose.pose.orientation = tf::createQuaternionMsgFromRollPitchYaw(0, 0, centerLocationMap.theta);
   mapPose.pose.position.x = centerLocationMap.x;
   mapPose.pose.position.y = centerLocationMap.y;
   geometry_msgs::PoseStamped odomPose;
   string x = "";
-  
+
   try
   { //attempt to get the transform of the center point in map frame to odom frame.
     tfListener->waitForTransform(publishedName + "/map", publishedName + "/odom", ros::Time::now(), ros::Duration(1.0));
     tfListener->transformPose(publishedName + "/odom", mapPose, odomPose);
   }
-  
+
   catch(tf::TransformException& ex) {
     ROS_INFO("Received an exception trying to transform a point from \"map\" to \"odom\": %s", ex.what());
     x = "Exception thrown " + (string)ex.what();
@@ -832,31 +846,31 @@ void transformMapCentertoOdom()
     infoLogPublisher.publish(msg);
     cout << msg.data << endl;
   }
-  
+
   // Use the position and orientation provided by the ros transform.
   centerLocationMapRef.x = odomPose.pose.position.x; //set centerLocation in odom frame
   centerLocationMapRef.y = odomPose.pose.position.y;
-  
+
  // cout << "x ref : "<< centerLocationMapRef.x << " y ref : " << centerLocationMapRef.y << endl;
-  
+
   float xdiff = centerLocationMapRef.x - centerLocationOdom.x;
   float ydiff = centerLocationMapRef.y - centerLocationOdom.y;
-  
+
   float diff = hypot(xdiff, ydiff);
-  
+
   if (diff > drift_tolerance)
   {
     centerLocationOdom.x += xdiff/diff;
     centerLocationOdom.y += ydiff/diff;
   }
-  
+
   //cout << "center x diff : " << centerLocationMapRef.x - centerLocationOdom.x << " center y diff : " << centerLocationMapRef.y - centerLocationOdom.y << endl;
   //cout << hypot(centerLocationMapRef.x - centerLocationOdom.x, centerLocationMapRef.y - centerLocationOdom.y) << endl;
-          
+
 }
 
 void humanTime() {
-  
+
   float timeDiff = (getROSTimeInMilliSecs()-startTime)/1e3;
   if (timeDiff >= 60) {
     minutesTime++;
@@ -867,7 +881,7 @@ void humanTime() {
     }
   }
   timeDiff = floor(timeDiff*10)/10;
-  
+
   double intP, frac;
   frac = modf(timeDiff, &intP);
   timeDiff -= frac;
@@ -875,7 +889,7 @@ void humanTime() {
   if (frac > 9) {
     frac = 0;
   }
-  
+
   //cout << "System has been Running for :: " << hoursTime << " : hours " << minutesTime << " : minutes " << timeDiff << "." << frac << " : seconds" << endl; //you can remove or comment this out it just gives indication something is happening to the log file
 }
 

--- a/src/rqt_rover_gui/src/rover_gui_plugin.cpp
+++ b/src/rqt_rover_gui/src/rover_gui_plugin.cpp
@@ -45,7 +45,7 @@ using namespace std;
 
 using boost::property_tree::ptree;
 
-namespace rqt_rover_gui 
+namespace rqt_rover_gui
 {
   RoverGUIPlugin::RoverGUIPlugin() :
       rqt_gui_cpp::Plugin(),
@@ -99,7 +99,7 @@ namespace rqt_rover_gui
     widget = new QWidget();
 
     ui.setupUi(widget);
-    
+
     context.addWidget(widget);
 
     // Next two lines allow us to catch keyboard input
@@ -172,7 +172,7 @@ namespace rqt_rover_gui
     // Receive waypoint commands from MapFrame
     connect(ui.map_frame, SIGNAL(sendWaypointCmd(WaypointCmd, int, float, float)), this, SLOT(receiveWaypointCmd(WaypointCmd, int, float, float)));
     connect(this, SIGNAL(sendWaypointReached(int)), ui.map_frame, SLOT(ReceiveWaypointReached(int)));
-    
+
     // Receive log messages from contained frames
     connect(ui.map_frame, SIGNAL(sendInfoLogMessage(QString)), this, SLOT(receiveInfoLogMessage(QString)));
 
@@ -208,7 +208,7 @@ namespace rqt_rover_gui
     ui.number_of_tags_combobox->setEnabled(false);
     ui.number_of_tags_combobox->setStyleSheet("color: grey; border:1px solid grey;");
 
-    ui.tab_widget->setCurrentIndex(1); //0: show sensor display tab; 1: show simulation parameters tab 
+    ui.tab_widget->setCurrentIndex(1); //0: show sensor display tab; 1: show simulation parameters tab
     ui.log_tab->setCurrentIndex(1);
 
     ui.texture_combobox->setItemData(0, QColor(Qt::white), Qt::TextColorRole);
@@ -259,7 +259,7 @@ void RoverGUIPlugin::joyEventHandler(const sensor_msgs::Joy::ConstPtr& joy_msg)
   {
     return;
   }
-  
+
      // Give the array values some helpful names:
     int left_stick_x_axis = 0; // Gripper fingers close and open
     int left_stick_y_axis = 1; // Gripper wrist up and down
@@ -573,14 +573,14 @@ void RoverGUIPlugin::obstacleEventHandler(const ros::MessageEvent<const std_msgs
     {
         emit updateObstacleCallCount("<font color='white'>"+QString::number(++obstacle_call_count)+"</font>");
     }
-    
+
     foragingElapsed = current_simulated_time_in_seconds - timer_start_time_in_seconds;
-    
-    //record the collision into files    
+
+    //record the collision into files
     if(timer_start_time_in_seconds > 0)//start to froaging
-    {	
+    {
 	    current_collisions = obstacle_call_count - previous_collisions;
-	        
+
 	    if(((int)foragingElapsed % 60 < 5 && foragingElapsed >= 58 && foragingElapsed - lastCollisionElapsedTime >= 58) || current_simulated_time_in_seconds >= timer_stop_time_in_seconds)
 	    {
 			collision_data<<current_collisions<<endl;
@@ -591,10 +591,10 @@ void RoverGUIPlugin::obstacleEventHandler(const ros::MessageEvent<const std_msgs
 				collision_data.close();
 			}
 		}
-		
+
 	}
-	
-	
+
+
 }
 
 // Takes the published score value from the ScorePlugin and updates the GUI
@@ -607,23 +607,23 @@ void RoverGUIPlugin::scoreEventHandler(const ros::MessageEvent<const std_msgs::S
     std::string tags_collected = msg->data;
 
     emit updateNumberOfTagsCollected("<font color='white'>"+QString::fromStdString(tags_collected)+"</font>");
-    
-	//record the score into files    
+
+	//record the score into files
     if(timer_start_time_in_seconds > 0)//start to froaging
-    {	
+    {
 	    current_collected_tags = stoi(tags_collected) - previous_collected_tags;
-	    
+
 	    if(((int)foragingElapsed % 60 < 5 && (int)foragingElapsed >= 58) || current_simulated_time_in_seconds + 2 >= timer_stop_time_in_seconds)
 	    {
 			score_data << current_collected_tags <<endl;
 			previous_collected_tags += current_collected_tags;
-			
+
 			if(current_simulated_time_in_seconds + 2 >= timer_stop_time_in_seconds)
 			{
 				score_data.close();
 			}
 		}
-	}	
+	}
 }
 
 void RoverGUIPlugin::simulationTimerEventHandler(const rosgraph_msgs::Clock& msg) {
@@ -647,7 +647,7 @@ void RoverGUIPlugin::simulationTimerEventHandler(const rosgraph_msgs::Clock& msg
     if (current_simulated_time_in_seconds <= 0.0) {
         return;
     }
-    
+
     if (is_timer_on) {
         if (current_simulated_time_in_seconds >= timer_stop_time_in_seconds) {
             is_timer_on = false;
@@ -693,7 +693,7 @@ void RoverGUIPlugin::currentRoverChangedEventHandler(QListWidgetItem *current, Q
     QString model_path = model_root+"/"+QString::fromStdString(selected_rover_name)+"/model.sdf";
 
     readRoverModelXML(model_path);
-    
+
     //Set up subscribers
     image_transport::ImageTransport it(nh);
     camera_subscriber = it.subscribe("/"+selected_rover_name+"/targets/image", 1, &RoverGUIPlugin::cameraEventHandler, this, image_transport::TransportHints("theora"));
@@ -806,6 +806,7 @@ void RoverGUIPlugin::pollRoversTimerEventHandler()
         gps_nav_solution_subscribers[*it].shutdown();
         ekf_subscribers[*it].shutdown();
         rover_diagnostic_subscribers[*it].shutdown();
+        center_location_offset_subscribers[*it].shutdown();
 
         // Delete the subscribers
         status_subscribers.erase(*it);
@@ -815,7 +816,8 @@ void RoverGUIPlugin::pollRoversTimerEventHandler()
         gps_nav_solution_subscribers.erase(*it);
         ekf_subscribers.erase(*it);
         rover_diagnostic_subscribers.erase(*it);
-        
+        center_location_offset_subscribers.erase(*it);
+
         // Shudown Publishers
         control_mode_publishers[*it].shutdown();
         waypoint_cmd_publishers[*it].shutdown();
@@ -834,7 +836,7 @@ void RoverGUIPlugin::pollRoversTimerEventHandler()
         selected_rover_name = "";
         rover_control_state.clear();
         rover_numSV_state.clear();
-        rover_names.clear();        
+        rover_names.clear();
         ui.rover_list->clearSelection();
         ui.rover_list->clear();
         ui.rover_diags_list->clear();
@@ -891,27 +893,27 @@ void RoverGUIPlugin::pollRoversTimerEventHandler()
     else
     {
     rover_names = new_rover_names;
-    
+
 	    emit sendInfoLogMessage("List of connected rovers has changed");
 	    selected_rover_name = "";
 	    ui.rover_list->clearSelection();
 	    ui.rover_list->clear();
-	
+
 	    // Also clear the rover diagnostics list
 	    ui.rover_diags_list->clear();
 	    ui.map_selection_list->clear();
-	    
+
 	    //Enable all autonomous button
 	    ui.all_autonomous_button->setEnabled(true);
 	    ui.all_autonomous_button->setStyleSheet("color: white; border:2px solid white;");
-	
+
 	    // This code is from above. Consider moving into a function or restructuring
 	    for(set<string>::const_iterator i = rover_names.begin(); i != rover_names.end(); ++i)
 	    {
 	        //Set up publishers
 	        control_mode_publishers[*i]=nh.advertise<std_msgs::UInt8>("/"+*i+"/mode", 10, true); // last argument sets latch to true
 	        waypoint_cmd_publishers[*i]=nh.advertise<swarmie_msgs::Waypoint>("/"+*i+"/waypoints/cmd", 10, true);
-	        
+
 	        //Set up subscribers
 	        status_subscribers[*i] = nh.subscribe("/"+*i+"/status", 10, &RoverGUIPlugin::statusEventHandler, this);
 	        waypoint_subscribers[*i] = nh.subscribe("/"+*i+"/waypoints", 10, &RoverGUIPlugin::waypointEventHandler, this);
@@ -921,7 +923,8 @@ void RoverGUIPlugin::pollRoversTimerEventHandler()
 	        gps_subscribers[*i] = nh.subscribe("/"+*i+"/odom/navsat", 10, &RoverGUIPlugin::GPSEventHandler, this);
 	        gps_nav_solution_subscribers[*i] = nh.subscribe("/"+*i+"/navsol", 10, &RoverGUIPlugin::GPSNavSolutionEventHandler, this);
 	        rover_diagnostic_subscribers[*i] = nh.subscribe("/"+*i+"/diagnostics", 1, &RoverGUIPlugin::diagnosticEventHandler, this);
-	
+          center_location_offset_subscribers[*i] = nh.subscribe("/"+*i+"/centerLocationOffset", 10, &RoverGUIPlugin::centerLocationOffsetHandler, this);
+
 	        RoverStatus rover_status;
 	        // Build new ui rover list string
 	        try
@@ -932,35 +935,35 @@ void RoverGUIPlugin::pollRoversTimerEventHandler()
 	        {
 	            emit sendInfoLogMessage("No status entry for rover " + QString::fromStdString(*i));
 	        }
-	
+
 	        QString rover_name_and_status = QString::fromStdString(*i) // Add the rover name
 	                                                + " (" // Delimiters needed for parsing the rover name and status when read
 	                                                +  QString::fromStdString(rover_status.status_msg) // Add the rover status
 	                                                + ")";
-	
+
 	        QListWidgetItem* new_item = new QListWidgetItem(rover_name_and_status);
 	        new_item->setForeground(Qt::green);
 	        ui.rover_list->addItem(new_item);
-	
+
 	        // Create the corresponding diagnostic data listwidgetitem
 	        QListWidgetItem* new_diags_item = new QListWidgetItem("");
-	
+
 	        // The user shouldn't be able to select the diagnostic output
 	        new_diags_item->setFlags(new_diags_item->flags() & ~Qt::ItemIsSelectable);
-	
+
 	        ui.rover_diags_list->addItem(new_diags_item);
-	
+
 	        // Add the map selection checkbox for this rover
 	        QListWidgetItem* new_map_selection_item = new QListWidgetItem("");
-	
+
 	        // set checkable but not selectable flags
 	        new_map_selection_item->setFlags(new_map_selection_item->flags() | Qt::ItemIsUserCheckable);
 	        new_map_selection_item->setFlags(new_map_selection_item->flags() & ~Qt::ItemIsSelectable);
 	        new_map_selection_item->setCheckState(Qt::Unchecked);
-	
+
 	        // Add to the widget list
 	        ui.map_selection_list->addItem(new_map_selection_item);
-	
+
 	    }
     }
 
@@ -1076,7 +1079,7 @@ void RoverGUIPlugin::diagnosticEventHandler(const ros::MessageEvent<const std_ms
     int red = 255;
     int green = 255;
     int blue = 255;
-    
+
     // Check whether there is sim update data. Will be < 0 for the sim rate if a physical rover is sending the data.
     // If so assume the diagnostic data is coming from a simulated rover.
     // TODO: replace with a proper message type so we don't need to use in stream flags like this.
@@ -1177,6 +1180,35 @@ void RoverGUIPlugin::diagnosticEventHandler(const ros::MessageEvent<const std_ms
 
 }
 
+void RoverGUIPlugin::centerLocationOffsetHandler(const ros::MessageEvent<std_msgs::Float32MultiArray const> &event)
+{
+  const std::string& publisher_name = event.getPublisherName();
+  const boost::shared_ptr<const std_msgs::Float32MultiArray> msg = event.getMessage();
+
+  std::vector<float> data = msg->data;
+
+  ui.map_frame->SetGlobalOffsetForRover(publisher_name, data[0], data[1]);
+  // adgj todo; get rover name in message...
+  // ui.map_frame->SetGlobalOffsetForRover("test", float x, float y);
+/*
+// some example code
+
+const std::string& publisher_name = event.getPublisherName();
+const ros::M_string& header = event.getConnectionHeader();
+ros::Time receipt_time = event.getReceiptTime();
+
+const boost::shared_ptr<const std_msgs::String> msg = event.getMessage();
+
+string log_msg = msg->data;
+
+emit sendInfoLogMessage(QString::fromStdString(publisher_name)
+                       + " <font color=Lime size=1>"
+                       + QString::fromStdString(log_msg)
+                       + "</font>");
+
+*/
+}
+
 // We use item changed signal as a proxy for the checkbox being clicked
 void RoverGUIPlugin::mapSelectionListItemChangedHandler(QListWidgetItem* changed_item)
 {
@@ -1240,14 +1272,14 @@ void RoverGUIPlugin::displayDiagLogMessage(QString msg)
     // Calculate the number of characters in the log. If the log size is larger than the max size specified
     // then find the position of the first newline that reduces the log size to less than the max size.
     // Delete all characters up to that position.
-    int overflow = diag_log_messages.size() - max_diag_log_length; 
-    
+    int overflow = diag_log_messages.size() - max_diag_log_length;
+
     // Get the position of the the first newline after the overflow amount
     int newline_pos = diag_log_messages.indexOf( "<br>", overflow, Qt::CaseSensitive );
-    
+
     // If the max size is exceeded and the number of characters to remove is less than
     // the size of the log remove those characters.
-    if ( overflow > 0 && newline_pos < diag_log_messages.size() ) {   
+    if ( overflow > 0 && newline_pos < diag_log_messages.size() ) {
       diag_log_messages.remove(0, newline_pos);
     }
 
@@ -1272,17 +1304,17 @@ void RoverGUIPlugin::displayInfoLogMessage(QString msg)
     // Calculate the number of characters in the log. If the log size is larger than the max size specified
     // then find the position of the first newline that reduces the log size to less than the max size.
     // Delete all characters up to that position.
-    int overflow = info_log_messages.size() - max_info_log_length; 
-    
+    int overflow = info_log_messages.size() - max_info_log_length;
+
     // Get the position of the the first newline after the overflow amount
     int newline_pos = info_log_messages.indexOf( "<br>", overflow, Qt::CaseSensitive );
-    
+
     // If the max size is exceeded and the number of characters to remove is less than
     // the size of the log remove those characters.
-    if ( overflow > 0 && newline_pos < info_log_messages.size() ) {   
+    if ( overflow > 0 && newline_pos < info_log_messages.size() ) {
       info_log_messages.remove(0, newline_pos);
     }
-    
+
     // Use the <br> tag to make log messages atomic for easier deletion later.
     info_log_messages += "<font color='white'>"+msg+"</font><br>";
 
@@ -1322,7 +1354,7 @@ void RoverGUIPlugin::autonomousRadioButtonEventHandler(bool marked)
 
     QString return_msg = stopROSJoyNode();
     emit sendInfoLogMessage(return_msg);
-    
+
     //Enable all stop button
     ui.all_stop_button->setEnabled(true);
     ui.all_stop_button->setStyleSheet("color: white; border:2px solid white;");
@@ -1368,11 +1400,11 @@ void RoverGUIPlugin::joystickRadioButtonEventHandler(bool marked)
 
     QString return_msg = startROSJoyNode();
     emit sendInfoLogMessage(return_msg);
-    
+
     //Enable all autonomous button
     ui.all_autonomous_button->setEnabled(true);
     ui.all_autonomous_button->setStyleSheet("color: white; border:2px solid white;");
-    
+
     //Show joystick frame
     ui.joystick_frame->setHidden(false);
 
@@ -1414,7 +1446,7 @@ void RoverGUIPlugin::allAutonomousButtonEventHandler()
     ui.joystick_control_radio_button->setChecked(false);
     ui.autonomous_control_radio_button->setChecked(true);
     ui.joystick_frame->setHidden(true);
-    
+
     // Disable all autonomous button
     ui.all_autonomous_button->setEnabled(false);
     ui.all_autonomous_button->setStyleSheet("color: grey; border:2px solid grey;");
@@ -1523,14 +1555,14 @@ void RoverGUIPlugin::allAutonomousButtonEventHandler()
 
     /* generate number between 0 and 1000: */
     int randNum = rand() % 5000;
-  
+
     score_data_filename += "_"+to_string(randNum)+".txt";
     score_data.open("results/"+score_data_filename);
-        
+
     collision_data_filename += "_"+to_string(randNum)+".txt";
     collision_data.open("results/"+collision_data_filename);
-        
-        
+
+
     // Experiment Timer END
 }
 
@@ -1605,7 +1637,7 @@ void RoverGUIPlugin::allStopButtonEventHandler()
     ui.joystick_control_radio_button->setChecked(true);
     ui.autonomous_control_radio_button->setChecked(false);
     ui.joystick_frame->setHidden(false);
-    
+
     //Disable all stop button
     ui.all_stop_button->setEnabled(false);
     ui.all_stop_button->setStyleSheet("color: grey; border:2px solid grey;");
@@ -1662,7 +1694,7 @@ void RoverGUIPlugin::customNumCubesRadioButtonEventHandler(bool toggled)
 	{
 	  ui.number_of_tags_combobox->setStyleSheet("color: grey; border:2px solid grey;");
 	}
-	
+
 }
 // Enable or disable custom distributions
 void RoverGUIPlugin::customWorldRadioButtonEventHandler(bool toggled)
@@ -1790,14 +1822,14 @@ void RoverGUIPlugin::buildSimulationButtonEventHandler()
     {
         emit sendInfoLogMessage("Not adding collection disk...");
     }
-    
-    arenaDim_publisher = nh.advertise<std_msgs::Float32>("/arena_dim", 10, this); 
+
+    arenaDim_publisher = nh.advertise<std_msgs::Float32>("/arena_dim", 10, this);
     std_msgs::Float32 msg_arena;
-    msg_arena.data = arena_dim; 
-    arenaDim_publisher.publish(msg_arena);  
-    
-    
-    
+    msg_arena.data = arena_dim;
+    arenaDim_publisher.publish(msg_arena);
+
+
+
     if(!ui.create_savable_world_checkbox->isChecked())
     {
         int n_rovers_created = 0;
@@ -1901,23 +1933,23 @@ void RoverGUIPlugin::buildSimulationButtonEventHandler()
           -0.785, // -0.25 * PI
            2.356  //  0.75 * PI
         };
-         
-        rover_publisher = nh.advertise<swarmie_msgs::RoverInfo>("/rovers", 10, this); 
+
+        rover_publisher = nh.advertise<swarmie_msgs::RoverInfo>("/rovers", 10, this);
         swarmie_msgs::RoverInfo msg_rover;
         //std_msgs::string roverName;
         geometry_msgs::Pose2D pos;
-        
+
         // Add rovers to the simulation and start the associated ROS nodes
         for (int i = 0; i < n_rovers; i++)
         {
-			
+
 			pos.x = rover_positions[i].x();
-	        pos.y = rover_positions[i].y(); 
-        
-        
+	        pos.y = rover_positions[i].y();
+
+
 			msg_rover.names.push_back(rovers[i].toStdString());
 			msg_rover.positions.push_back(pos);
-			
+
 			// add the global offset for sim rovers
             ui.map_frame->SetGlobalOffsetForRover(rovers[i].toStdString(), rover_positions[i].x(), rover_positions[i].y());
             ui.map_frame->SetUniqueRoverColor(rovers[i].toStdString(), rover_colors[i]);
@@ -2036,7 +2068,7 @@ void RoverGUIPlugin::clearSimulationButtonEventHandler()
 
     emit sendInfoLogMessage("Shutting down subscribers...");
 
-    for (map<string,ros::Subscriber>::iterator it=encoder_subscribers.begin(); it!=encoder_subscribers.end(); ++it) 
+    for (map<string,ros::Subscriber>::iterator it=encoder_subscribers.begin(); it!=encoder_subscribers.end(); ++it)
       {
 	qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
 	it->second.shutdown();
@@ -2070,21 +2102,21 @@ void RoverGUIPlugin::clearSimulationButtonEventHandler()
 
     // Possible error - the following seems to shutdown all subscribers not just those from simulation
 
-    for (map<string,ros::Subscriber>::iterator it=status_subscribers.begin(); it!=status_subscribers.end(); ++it) 
+    for (map<string,ros::Subscriber>::iterator it=status_subscribers.begin(); it!=status_subscribers.end(); ++it)
       {
 	qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
 	it->second.shutdown();
       }
     status_subscribers.clear();
 
-    for (map<string,ros::Subscriber>::iterator it=waypoint_subscribers.begin(); it!=waypoint_subscribers.end(); ++it) 
+    for (map<string,ros::Subscriber>::iterator it=waypoint_subscribers.begin(); it!=waypoint_subscribers.end(); ++it)
       {
 	qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
 	it->second.shutdown();
       }
     waypoint_subscribers.clear();
 
-    for (map<string,ros::Subscriber>::iterator it=obstacle_subscribers.begin(); it!=obstacle_subscribers.end(); ++it) 
+    for (map<string,ros::Subscriber>::iterator it=obstacle_subscribers.begin(); it!=obstacle_subscribers.end(); ++it)
       {
 	qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
 	it->second.shutdown();
@@ -2110,8 +2142,8 @@ void RoverGUIPlugin::clearSimulationButtonEventHandler()
 	it->second.shutdown();
       }
     waypoint_cmd_publishers.clear();
-    
-    
+
+
     return_msg += sim_mgr.stopGazeboClient();
     qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
     return_msg += "<br>";
@@ -2350,12 +2382,12 @@ QString RoverGUIPlugin::addPowerLawTargets()
     int power4 =0;
     int diffFoodCount =0;
     int singleClusterCount =0;
-    int otherClusterCount =0; 
+    int otherClusterCount =0;
     int modDiff =0;
     int target_cluster_size_clearance;
     vector<int> clusterNums;
-	vector<int> clusterWidths; 
-	
+	vector<int> clusterWidths;
+
     QString output = "";
 
     float proposed_x, proposed_x2;
@@ -2375,7 +2407,7 @@ QString RoverGUIPlugin::addPowerLawTargets()
     PowerRank = priorPowerRank + 1;
     diffFoodCount = FoodCount - number_of_tags.toInt();
     modDiff = diffFoodCount % PowerRank;
-    
+
     if (number_of_tags.toInt() % PowerRank == 0){
         singleClusterCount = number_of_tags.toInt() / PowerRank;
         otherClusterCount = singleClusterCount;
@@ -2384,7 +2416,7 @@ QString RoverGUIPlugin::addPowerLawTargets()
         otherClusterCount = number_of_tags.toInt() / PowerRank + 1;
         singleClusterCount = otherClusterCount - modDiff;
     }
-    
+
     for(int i = 0; i < PowerRank; i++) {
 		clusterNums.push_back(powerLawLength * powerLawLength);
 		powerLawLength *= 2;
@@ -2394,43 +2426,43 @@ QString RoverGUIPlugin::addPowerLawTargets()
 		powerLawLength /= 2;
 		clusterWidths.push_back(powerLawLength);
 	}
-    
+
     for(int h = 0; h < clusterNums.size(); h++) {
 	  for(int i = 0; i < clusterNums[h]; i++) {
 		  target_cluster_size_clearance = 0.1*clusterWidths[h];
 		  d = arena_dim/2.0-(barrier_clearance+ target_cluster_size_clearance);
-		  
+
 		  do
           {
            proposed_x = d - ((float) rand()) / RAND_MAX*2*d;
            proposed_y = d - ((float) rand()) / RAND_MAX*2*d;
           }
           while (sim_mgr.isLocationOccupied(proposed_x, proposed_y, target_cluster_size_clearance));
-          
+
           emit sendInfoLogMessage("Tried to place cluster "+QString::number(clusters_placed)+" at " + QString::number(proposed_x) + " " + QString::number(proposed_y));
-          clusters_placed++;             
-		   
+          clusters_placed++;
+
 		  proposed_y2 = proposed_y - target_cluster_size_clearance;
-		   
+
           for(int j = 0; j < clusterWidths[h]; j++) {
 			  proposed_x2 = proposed_x - target_cluster_size_clearance;
-		      for(int k = 0; k < clusterWidths[h]; k++) { 
+		      for(int k = 0; k < clusterWidths[h]; k++) {
 			    output += sim_mgr.addModel(QString("at")+QString::number(0),  QString("at")+QString::number(cube_index), proposed_x2, proposed_y2, 0, target_cluster_size_1_clearance);
                 proposed_x2 += target_cluster_size_1_clearance;
                 cube_index++;
                 progress_dialog.setValue(cube_index*100.0f/number_of_tags.toInt());
                 qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
-            
-            
+
+
 			    foodPlaced++;
 			    if (foodPlaced == singleClusterCount + h * otherClusterCount) break;
 		      }
                proposed_y2 += target_cluster_size_1_clearance;
-               
+
 		      if (foodPlaced == singleClusterCount + h * otherClusterCount) break;
 	      }
 		  emit sendInfoLogMessage("<font color=green>Succeeded.</font>");
-		  
+
 		  if (foodPlaced == singleClusterCount + h * otherClusterCount) break;
 	  }
 	}
@@ -2737,7 +2769,7 @@ bool RoverGUIPlugin::eventFilter(QObject *target, QEvent *event)
 {
     sensor_msgs::Joy joy_msg;
     joy_msg.axes = {0.0,0.0,0.0,0.0,0.0,0.0};
-    
+
     if (joystick_publisher)
     {
 
@@ -2973,7 +3005,7 @@ void RoverGUIPlugin::receiveWaypointCmd(WaypointCmd cmd, int id, float x, float 
     msg.id = id;
     msg.x = x;
     msg.y = y;
-    
+
     waypoint_cmd_publishers[selected_rover_name].publish(msg);
 }
 
@@ -2989,4 +3021,3 @@ RoverGUIPlugin::~RoverGUIPlugin()
 
 
 PLUGINLIB_EXPORT_CLASS(rqt_rover_gui::RoverGUIPlugin, rqt_gui_cpp::Plugin)
-

--- a/src/rqt_rover_gui/src/rover_gui_plugin.cpp
+++ b/src/rqt_rover_gui/src/rover_gui_plugin.cpp
@@ -1183,30 +1183,21 @@ void RoverGUIPlugin::diagnosticEventHandler(const ros::MessageEvent<const std_ms
 void RoverGUIPlugin::centerLocationOffsetHandler(const ros::MessageEvent<std_msgs::Float32MultiArray const> &event)
 {
   const std::string& publisher_name = event.getPublisherName();
+
+  // We need to parse the publisher name to get the rover name
+  //     publisher_name = /roverName_BEHAVIOUR; we just want "roverName"
+  const std::string& rover_name = publisher_name.substr(1, publisher_name.find("_") - 1);
   const boost::shared_ptr<const std_msgs::Float32MultiArray> msg = event.getMessage();
 
+  // data[0] = X
+  // data[1] = Y
+  // data[2] = theta
   std::vector<float> data = msg->data;
 
-  ui.map_frame->SetGlobalOffsetForRover(publisher_name, data[0], data[1]);
-  // adgj todo; get rover name in message...
-  // ui.map_frame->SetGlobalOffsetForRover("test", float x, float y);
-/*
-// some example code
+  // for debugging
+  // emit sendInfoLogMessage("[CenterLocationOffsetHandler] !!! updating global offset for: " + QString::fromStdString(rover_name));
 
-const std::string& publisher_name = event.getPublisherName();
-const ros::M_string& header = event.getConnectionHeader();
-ros::Time receipt_time = event.getReceiptTime();
-
-const boost::shared_ptr<const std_msgs::String> msg = event.getMessage();
-
-string log_msg = msg->data;
-
-emit sendInfoLogMessage(QString::fromStdString(publisher_name)
-                       + " <font color=Lime size=1>"
-                       + QString::fromStdString(log_msg)
-                       + "</font>");
-
-*/
+  ui.map_frame->SetGlobalOffsetForRover(rover_name, data[0], data[1]);
 }
 
 // We use item changed signal as a proxy for the checkbox being clicked

--- a/src/rqt_rover_gui/src/rover_gui_plugin.h
+++ b/src/rqt_rover_gui/src/rover_gui_plugin.h
@@ -89,7 +89,7 @@ namespace rqt_rover_gui {
   class RoverGUIPlugin : public rqt_gui_cpp::Plugin
   {
     Q_OBJECT
-      
+
   public:
 
     RoverGUIPlugin();
@@ -117,7 +117,7 @@ namespace rqt_rover_gui {
     void scoreEventHandler(const ros::MessageEvent<std_msgs::String const> &event);
     void simulationTimerEventHandler(const rosgraph_msgs::Clock& msg);
     void diagnosticEventHandler(const ros::MessageEvent<std_msgs::Float32MultiArray const> &event);
-
+    void centerLocationOffsetHandler(const ros::MessageEvent<std_msgs::Float32MultiArray const> &event);
     void centerUSEventHandler(const sensor_msgs::Range::ConstPtr& msg);
     void leftUSEventHandler(const sensor_msgs::Range::ConstPtr& msg);
     void rightUSEventHandler(const sensor_msgs::Range::ConstPtr& msg);
@@ -146,7 +146,7 @@ namespace rqt_rover_gui {
 
     void sendWaypointReached(int waypoint_id);
     void sendInfoLogMessage(QString); // log message updates need to be implemented as signals so they can be used in ROS event handlers.
-    void sendDiagLogMessage(QString);    
+    void sendDiagLogMessage(QString);
     void sendDiagsDataUpdate(QString, QString, QColor); // Provide the item to update and the diags text and text color
 
     // Joystick output - Drive
@@ -230,6 +230,7 @@ namespace rqt_rover_gui {
     map<string,ros::Subscriber> ekf_subscribers;
     map<string,ros::Subscriber> rover_diagnostic_subscribers;
     map<string,ros::Subscriber> waypoint_subscribers;
+    map<string,ros::Subscriber> center_location_offset_subscribers;
     ros::Subscriber us_center_subscriber;
     ros::Subscriber us_left_subscriber;
     ros::Subscriber us_right_subscriber;
@@ -273,20 +274,20 @@ namespace rqt_rover_gui {
     double getHours(double seconds);
     double getMinutes(double seconds);
     double getSeconds(double seconds);
-    
+
     int previous_collected_tags =0;
     int current_collected_tags = 0;
     string score_data_filename = "DDSA_score_data";
-    ofstream score_data; 
+    ofstream score_data;
     double foragingElapsed = 0;
     double lastCollisionElapsedTime = 0;
-    
-    
+
+
     int previous_collisions =0;
     int current_collisions = 0;
     string collision_data_filename = "DDSA_collision_data";
-    ofstream collision_data; 
-     
+    ofstream collision_data;
+
     bool display_sim_visualization;
 
     // Object clearance. These values are used to quickly determine where objects can be placed in the simulation
@@ -322,4 +323,3 @@ namespace rqt_rover_gui {
 } // end namespace
 
 #endif // ROVERGUIPLUGIN
-


### PR DESCRIPTION
This update adds a publisher/subscriber to the rover so that the Global Offset of physical rovers can be represented properly in the Map Frame in the RQT GUI.

Currently, this global offset only works for simulated rovers, but with this addition physical rovers will be able to use it as well.

This is especially important in the DDSA because the paths shown in the map frame will be more accurate and true to life---the paths themselves won't change, but their relative locations to the other rovers will be adjusted to appear more accurately.